### PR TITLE
[FIX] API: validate divided by zero

### DIFF
--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -21,7 +21,7 @@ class Restaurant < ApplicationRecord
         rating.append(restaurant.rating)
       end
     end
-    standard_deviation(restaurants_statistics, rating)
+    standard_deviation(restaurants_statistics, rating) if !rating.empty?
     restaurants_statistics
   end
 


### PR DESCRIPTION
Was validated when any restaurants are inside the circle.